### PR TITLE
Update README.md to fix getting the token value from the input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ jobs:
           secret-value: ${{ secrets[matrix.secretname] }}
           destination-repository-name: ${{ fromJSON(inputs.json-migration-spec)[matrix.secretname].destinationRepositoryName }} # e.g. "repo-01"
           destination-repository-owner: ${{ fromJSON(inputs.json-migration-spec)[matrix.secretname].destinationRepositoryOwner }} # e.g. "targetorganization-a"
-          destination-github-token: ${{ secrets[fromJSON(inputs.json-migration-spec)[matrix.secretname].destinationPersonalAccessTokenName] }} # e.g. secret["the_pat_a"]
+          destination-github-token: ${{ fromJSON(inputs.json-migration-spec)[matrix.secretname].destinationPersonalAccessTokenName }} # e.g. secret["the_pat_a"]
 ```
 
 ### Copy an `environment` secret


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to correct the handling of GitHub tokens in the `jobs:` section.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R142): Updated the `destination-github-token` to correctly parse the token name using `fromJSON` instead of `secrets`.

There is no need to use "secrets[....]" for a token that is passed in. That is already handled by default by GitHub Actions to redact the value from the runner logs.